### PR TITLE
Fix CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,11 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      # Run the test for all branches
-      - test
+      # Run the test for all branches and version tags
+      - test:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - deploy:
           requires:
             - test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+.idea


### PR DESCRIPTION
Currently CI pipeline does not work on version tags. You can check the 3rd pipeline in the [link](https://app.circleci.com/pipelines/github/zeplin/zeplin-prism-extras). Test job does not work on tags and deployment job requires test job. With this PR I hope, I will fix the issue. I didn't have a chance to test it, 😅 but it will work. 🤞 